### PR TITLE
Build demo home + scenario 1 SMS flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,7 @@ __azurite_db*__.json
 
 # Generated deployment artifact
 requirements.txt
+
+# Generated conversation simulation output
+conv_simulation.txt
+conv_simulation.html

--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,29 @@
-.PHONY: setup run test test-twilio test-azure test-integration test-all lint format requirements
+.PHONY: setup run \
+        test test-twilio test-azure test-integration test-all \
+        lint format requirements \
+        conv-generate conv-terminal conv-browser
 
+###################
+# Setup & Running #
+###################
 setup:
 	uv sync
 	cp azure_functions/local.settings.copythis.json azure_functions/local.settings.json
 
-run:
+func-run:
 	cd azure_functions && uv run func start
 
+###########
+# Testing #
+###########
 test:
-	uv run python -m pytest --ignore=tests/integration
-
-test-twilio:
-	uv run --group integration python -m pytest tests/integration/test_twilio_sms.py -v -rs -s
+	uv run python -m pytest --ignore=tests/integration/remote
 
 test-azure:
-	uv run python scripts/run_azure_tests.py
+	uv run --group integration python -m pytest tests/integration/remote/test_azure_functions.py -v -rs -s
+
+test-twilio:
+	uv run --group integration python -m pytest tests/integration/remote/test_twilio_sms.py -v -rs -s
 
 test-integration:
 	uv run --group integration python -m pytest tests/integration -v -rs -s
@@ -22,6 +31,9 @@ test-integration:
 test-all:
 	uv run --group integration python -m pytest -v -rs -s
 
+################
+# Code Quality #
+################
 lint:
 	uv run ruff check .
 
@@ -30,3 +42,19 @@ format:
 
 requirements:
 	uv export --no-dev --no-hashes --no-emit-project -o requirements.txt
+
+###################
+# Conv Simulation #
+###################
+conv-generate:
+	uv run scripts/conv_simulation.py > conv_simulation.txt
+	uvx ansi2html < conv_simulation.txt > conv_simulation.html
+
+conv-terminal: conv_simulation.txt
+	cat conv_simulation.txt
+
+conv-browser: conv_simulation.html
+	open conv_simulation.html
+
+conv_simulation.txt conv_simulation.html:
+	$(MAKE) conv-generate

--- a/README.md
+++ b/README.md
@@ -14,21 +14,26 @@ An Azure Functions app that sends SMS court date reminders via Twilio.
    npm i -g azure-functions-core-tools@4
    ```
    Alternatively, follow the [official instructions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-run-local?tabs=macos%2Cisolated-process%2Cnode-v4%2Cpython-v2%2Chttp-trigger%2Ccontainer-apps&pivots=programming-language-python#install-the-azure-functions-core-tools).
-4. Start Azurite storage emulator:
+4. (Optional) Start Azurite storage emulator — only needed once `AzureTableStateStore` is implemented (currently a stub). For now, use `STATE_BACKEND=memory` in `local.settings.json`:
    ```bash
    docker run -p 10000:10000 -p 10001:10001 -p 10002:10002 mcr.microsoft.com/azure-storage/azurite azurite --disableTelemetry
    ```
 
 ## Running Locally
 
-1. Start the Azure Function:
+1. Start the Azure Function - you will see a stream of logs in this terminal session:
    ```bash
-   make run
+   make func-run
    ```
-2. Trigger the function:
+2. In a separate terminal session, trigger the function:
    ```bash
-   curl -X POST http://localhost:7071/api/twilioHandler --data '{"name": "World"}'
+   curl -X POST http://localhost:7071/api/twilioHandler \
+     --data 'Body=hello&From=%2B15550000001'
    ```
+
+If it succeeds, you'll see a message output
+
+Note, the subsequent instructions walk through more realistic flows.  Above `POST` request is just to show a single simple API interaction.
 
 ## Running Tests
 
@@ -39,19 +44,28 @@ make test
 
 ### Integration Tests
 
-Integration tests hit real external services and require credentials.
+Integration tests are split into local (no server required) and remote (hit real services).
 
 | Command | What it does |
 |---|---|
-| `make test` | Unit tests only (default) |
-| `make test-twilio` | Twilio SMS integration tests |
-| `make test-azure` | Azure Functions integration tests |
-| `make test-integration` | All integration tests |
-| `make test-all` | Unit + integration tests |
+| `make test-twilio` | Twilio SMS tests — sends real SMS, requires credentials |
+| `make test-azure` | Azure Functions host tests — requires `make func-run` |
+| `make test-integration` | All remote integration tests |
+| `make test-all` | Unit + all integration tests |
 
 **Twilio SMS setup** — sends actual SMS messages to a test number:
 1. Copy `.template.env` to `.env` and fill in your Twilio credentials
 2. Run `make test-twilio`
+
+As it runs and if it's succeeding, you'll see something like:
+
+```text
+Sent (SID: SM05531c6d6f98aac52338542b68b7fff3)
+Waiting 5s...
+Sending: You have an appointment in 5 seconds
+Sent (SID: SM49b05ad155691131b05065b5e790b233)
+...
+```
 
 ## Deployment via GitHub Actions
 
@@ -72,21 +86,31 @@ Deployment is handled by the GitHub Action [deploy_to_azure_functions.yml](.gith
 
 ### Example cURL request against deployed app
 
-Once the Azure function is deployed, here is how to get the Invoke URL (used below in "Example cURL request against deployed app"):
+Once the Azure function is deployed, get the Invoke URL by running:
 
 ```bash
 func azure functionapp list-functions choose-your-own-adventure-demo-flex-eus --show-keys
 ```
 
-Note, in the URL below, replace `<redacted>` with actual value from Invoke URL
+Output will look like:
+
+```
+Functions in choose-your-own-adventure-demo-flex-eus:
+    twilioHandler - [httpTrigger]
+        Invoke url: https://choose-your-own-adventure-demo-flex-eus-dpaedjd2evcxhcd5.eastus-01.azurewebsites.net/api/twiliohandler?code=<your-key>
+```
+
+Copy the full `Invoke url` value. In the cURL below, replace `<redacted>` with the `code=...` query parameter value from that URL.
 
 ```bash
 curl -L "https://choose-your-own-adventure-demo-flex-eus-dpaedjd2evcxhcd5.eastus-01.azurewebsites.net/api/twiliohandler?code=<redacted>" \
-  -H "Content-Type: application/json" \
-  --data '{"name": "World"}'
+  --data 'Body=hello&From=%2B15550000001'
 ```
 
 Expected response:
-```
-Hello, World. This HTTP triggered function executed successfully.
+```xml
+<Response><Message>Welcome to the GA Court Reminder demo - which scenario do you want to play out?
+
+(1) 7, 3, 1 countdown
+(2) Missed + Warrant [Unavailable atm]</Message></Response>
 ```

--- a/azure_functions/function_app.py
+++ b/azure_functions/function_app.py
@@ -1,18 +1,63 @@
-import azure.functions as func
+import json
 import logging
+import os
+
+import azure.functions as func
 
 from court_reminder import __version__
+from court_reminder.state import AzureTableStateStore, InMemoryStateStore
+from court_reminder.twilio_handler import advance_scenario, handle_inbound_sms
 
 app = func.FunctionApp(http_auth_level=func.AuthLevel.FUNCTION)
 
 
+_memory_store = InMemoryStateStore()
+
+
+def _get_state_store():
+    if os.environ.get("STATE_BACKEND") == "memory":
+        return _memory_store
+    return AzureTableStateStore(table_client=None)
+
+
+def format_twiml(messages: list[str]) -> str:
+    body = "".join(f"<Message>{m}</Message>" for m in messages)
+    return f"<Response>{body}</Response>"
+
+
 @app.route(route="twilioHandler")
 def twilioHandler(req: func.HttpRequest) -> func.HttpResponse:
-    logging.info(
-        "court-reminder %s: HTTP trigger function processed a request.", __version__
+    logging.info("court-reminder %s: twilioHandler triggered.", __version__)
+
+    phone = req.form.get("From", "")
+    body = req.form.get("Body", "")
+    logging.info("From=%s Body=%s", phone, body)
+
+    state_store = _get_state_store()
+    messages = handle_inbound_sms(phone, body, state_store)
+
+    return func.HttpResponse(
+        format_twiml(messages),
+        status_code=200,
+        mimetype="application/xml",
     )
 
-    body = req.get_json()
-    logging.info("received body: %s", body)
 
-    return func.HttpResponse("done\n", status_code=200)
+@app.route(route="advanceScenario")
+def advanceScenario(req: func.HttpRequest) -> func.HttpResponse:
+    logging.info("court-reminder %s: advanceScenario triggered.", __version__)
+
+    try:
+        data = req.get_json()
+        phone = data.get("phone", "")
+    except ValueError:
+        return func.HttpResponse("Missing JSON body with 'phone'", status_code=400)
+
+    state_store = _get_state_store()
+    messages = advance_scenario(phone, state_store)
+
+    return func.HttpResponse(
+        json.dumps({"messages": messages}),
+        status_code=200,
+        mimetype="application/json",
+    )

--- a/azure_functions/local.settings.copythis.json
+++ b/azure_functions/local.settings.copythis.json
@@ -2,7 +2,8 @@
   "IsEncrypted": false,
   "Values": {
     "AzureWebJobsStorage": "UseDevelopmentStorage=true",
-    "FUNCTIONS_WORKER_RUNTIME": "python"
+    "FUNCTIONS_WORKER_RUNTIME": "python",
+    "STATE_BACKEND": "memory"
   },
   "Host": {
     "LocalHttpPort": 7071

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,8 +23,9 @@ integration = [
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 markers = [
-    "integration_twilio: Twilio SMS integration tests (require credentials)",
-    "integration_azure: Azure Functions integration tests (require running function host)",
+    "integration_local: integration tests that run with no external dependencies",
+    "integration_azure: integration tests that require a running Azure Functions host (make func-run)",
+    "integration_twilio: integration tests that require Twilio credentials (.env)",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/scripts/conv_simulation.py
+++ b/scripts/conv_simulation.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""
+Demo flow harness — simulates realistic SMS conversations and prints them as chat logs.
+
+Calls court_reminder logic directly (no HTTP server needed).
+
+Usage:
+    uv run python tests/harness.py
+"""
+
+from court_reminder.state import InMemoryStateStore
+from court_reminder.twilio_handler import advance_scenario, handle_inbound_sms
+
+PHONE = "+14045550000"
+
+_last_system_msg: str = ""
+
+# ANSI colors
+_RESET  = "\033[0m"
+_BOLD   = "\033[1m"
+_DIM    = "\033[2m"
+_CYAN   = "\033[96m"   # user texts
+_GREEN  = "\033[92m"   # system replies
+_YELLOW = "\033[93m"   # timed advance marker
+_WHITE  = "\033[97m"
+
+
+def _store():
+    return InMemoryStateStore()
+
+
+def _bubble(label: str, color: str, text: str):
+    indent = "    "
+    header = f"{_BOLD}{color}{label}{_RESET}"
+    lines = text.splitlines()
+    print(f"{indent}{header}")
+    for line in lines:
+        print(f"{indent}  {color}{line}{_RESET}")
+    print()
+
+
+def sms(store, body: str):
+    global _last_system_msg
+    _bubble("📱 You", _CYAN, body)
+    for msg in handle_inbound_sms(PHONE, body, store):
+        _bubble("💬 System", _GREEN, msg)
+        _last_system_msg = msg
+
+
+def advance(store):
+    global _last_system_msg
+    print(f"    {_DIM}{_YELLOW}⏱  [timed advance]{_RESET}\n")
+    msgs = advance_scenario(PHONE, store)
+    for msg in msgs:
+        _bubble("💬 System", _GREEN, msg)
+        _last_system_msg = msg
+
+
+def flow(title: str):
+    global _last_system_msg
+    if _last_system_msg and "session has ended" not in _last_system_msg:
+        print(f"    {_DIM}...{_RESET}\n")
+    _last_system_msg = ""
+    print(f"\n{_BOLD}{_WHITE}{'━' * 54}{_RESET}")
+    print(f"{_BOLD}{_WHITE}  {title}{_RESET}")
+    print(f"{_BOLD}{_WHITE}{'━' * 54}{_RESET}\n")
+    return _store()
+
+
+# ---------------------------------------------------------------------------
+# Flow 1: Happy path — full 7-3-1 countdown
+# ---------------------------------------------------------------------------
+s = flow("Flow 1: Happy path — full countdown")
+sms(s, "hello")
+sms(s, "1")
+advance(s)  # countdown_7min
+advance(s)  # countdown_3min
+advance(s)  # countdown_1min
+advance(s)  # missed
+advance(s)  # rescheduled countdown_7min
+sms(s, "EXIT")
+
+# ---------------------------------------------------------------------------
+# Flow 2: User takes a few tries to pick a valid scenario
+# ---------------------------------------------------------------------------
+s = flow("Flow 2: User fumbles with scenario selection")
+sms(s, "hey there")
+sms(s, "what is this")
+sms(s, "2")        # unavailable
+sms(s, "banana")   # still not valid
+sms(s, "1")
+advance(s)
+
+# ---------------------------------------------------------------------------
+# Flow 3: User texts mid-countdown, then exits
+# ---------------------------------------------------------------------------
+s = flow("Flow 3: User texts mid-countdown, then exits")
+sms(s, "1")
+advance(s)  # countdown_7min
+sms(s, "am I going to jail?")
+sms(s, "hello??")
+advance(s)  # countdown_3min
+sms(s, "finish")
+
+# ---------------------------------------------------------------------------
+# Flow 4: Exit immediately from home, then re-enter
+# ---------------------------------------------------------------------------
+s = flow("Flow 4: Exit from home, then re-enter")
+sms(s, "END")
+sms(s, "1")
+advance(s)
+
+# ---------------------------------------------------------------------------
+# Flow 5: Exit during countdown, re-enter fresh
+# ---------------------------------------------------------------------------
+s = flow("Flow 5: Exit mid-countdown, re-enter and restart")
+sms(s, "1")
+advance(s)  # countdown_7min
+advance(s)  # countdown_3min
+sms(s, "EXIT")
+sms(s, "hello")   # back to welcome
+sms(s, "1")       # fresh start, new court_datetime
+advance(s)
+
+if _last_system_msg and "session has ended" not in _last_system_msg:
+    print(f"    {_DIM}...{_RESET}\n")

--- a/src/court_reminder/message_parser.py
+++ b/src/court_reminder/message_parser.py
@@ -1,1 +1,24 @@
 """Parse incoming SMS messages into structured commands."""
+
+from dataclasses import dataclass
+
+_EXIT_WORDS = {"exit", "finish", "end"}
+
+
+@dataclass
+class ParsedMessage:
+    raw: str
+    is_exit: bool
+    scenario_choice: int | None
+
+
+def parse(body: str) -> ParsedMessage:
+    stripped = body.strip()
+    lowered = stripped.lower()
+
+    if lowered in _EXIT_WORDS:
+        return ParsedMessage(raw=body, is_exit=True, scenario_choice=None)
+    elif stripped.isdigit():
+        return ParsedMessage(raw=body, is_exit=False, scenario_choice=int(stripped))
+    else:
+        return ParsedMessage(raw=body, is_exit=False, scenario_choice=None)

--- a/src/court_reminder/scenarios/_utils.py
+++ b/src/court_reminder/scenarios/_utils.py
@@ -1,0 +1,14 @@
+from datetime import datetime, timedelta, timezone
+
+_EXIT_HINT = "\n\nText EXIT / FINISH / END to end the demo"
+
+def now_plus(minutes: int) -> str:
+    return (datetime.now(timezone.utc) + timedelta(minutes=minutes)).isoformat()
+
+
+def parse_dt(s: str) -> datetime:
+    return datetime.fromisoformat(s)
+
+
+def format_dt(s: str) -> str:
+    return parse_dt(s).strftime("%I:%M %p %Z")

--- a/src/court_reminder/scenarios/base.py
+++ b/src/court_reminder/scenarios/base.py
@@ -1,1 +1,19 @@
 """Base scenario interface for conversation flows."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class ScenarioResponse:
+    messages: list[str]
+    next_scenario: str
+    next_step: str
+    court_datetime: str | None = None
+
+
+class BaseScenario:
+    def handle(self, step: str, message_body: str, court_datetime: str | None) -> ScenarioResponse:
+        raise NotImplementedError
+
+    def advance(self, step: str, court_datetime: str | None) -> ScenarioResponse:
+        raise NotImplementedError

--- a/src/court_reminder/scenarios/home.py
+++ b/src/court_reminder/scenarios/home.py
@@ -1,0 +1,47 @@
+"""Home scenario — demo entry point and scenario selector."""
+
+from court_reminder.message_parser import parse
+from court_reminder.scenarios._utils import format_dt, now_plus, _EXIT_HINT
+from court_reminder.scenarios.base import BaseScenario, ScenarioResponse
+
+_WELCOME = (
+    "Welcome to the GA Court Reminder demo - which scenario do you want to play out?\n\n"
+    "(1) 7, 3, 1 countdown\n"
+    "(2) Missed + Warrant [Unavailable atm]"
+)
+
+_UNAVAILABLE = "Sorry, that scenario is not available yet."
+
+
+class HomeScenario(BaseScenario):
+    def handle(self, step: str, message_body: str, court_datetime: str | None) -> ScenarioResponse:
+        msg = parse(message_body)
+
+        if msg.scenario_choice == 1:
+            dt = now_plus(10)
+            return ScenarioResponse(
+                messages=[
+                    f"Welcome - your fake court date is 10 minutes from now at {format_dt(dt)}. "
+                    "We'll text you 7 min, 3 min, and 1 min before your fake court date."
+                    + _EXIT_HINT
+                ],
+                next_scenario="scenario_1",
+                next_step="countdown_7min",
+                court_datetime=dt,
+            )
+
+        if msg.scenario_choice == 2:
+            return ScenarioResponse(
+                messages=[_UNAVAILABLE, _WELCOME],
+                next_scenario="home",
+                next_step="welcome",
+            )
+
+        return ScenarioResponse(
+            messages=[_WELCOME],
+            next_scenario="home",
+            next_step="welcome",
+        )
+
+    def advance(self, step: str, court_datetime: str | None) -> ScenarioResponse:
+        raise NotImplementedError("HomeScenario has no timed advance steps")

--- a/src/court_reminder/scenarios/scenario_1.py
+++ b/src/court_reminder/scenarios/scenario_1.py
@@ -1,0 +1,65 @@
+"""Scenario 1 — 7-3-1 countdown demo flow."""
+
+from court_reminder.scenarios._utils import format_dt, now_plus, _EXIT_HINT
+from court_reminder.scenarios.base import BaseScenario, ScenarioResponse
+
+_LOCATION = "1234 Main St, Atlanta, GA\nCourt Room ABC"
+
+
+def _reminder(n: int, court_datetime: str) -> str:
+    return (
+        f"Your fake court date is {n} minute(s) from now.\n\n"
+        f"Details:\n{_LOCATION}\n{format_dt(court_datetime)}"
+        + _EXIT_HINT
+    )
+
+
+class Scenario1(BaseScenario):
+    def handle(self, step: str, message_body: str, court_datetime: str | None) -> ScenarioResponse:
+        """Acknowledge inbound SMS during a running countdown."""
+        return ScenarioResponse(
+            messages=["Your countdown is running. Text EXIT / FINISH / END to end the demo."],
+            next_scenario="scenario_1",
+            next_step=step,
+            court_datetime=court_datetime,
+        )
+
+    def advance(self, step: str, court_datetime: str | None) -> ScenarioResponse:
+        if step == "countdown_7min":
+            return ScenarioResponse(
+                messages=[_reminder(7, court_datetime)],  # type: ignore[arg-type]
+                next_scenario="scenario_1",
+                next_step="countdown_3min",
+                court_datetime=court_datetime,
+            )
+
+        if step == "countdown_3min":
+            return ScenarioResponse(
+                messages=[_reminder(3, court_datetime)],  # type: ignore[arg-type]
+                next_scenario="scenario_1",
+                next_step="countdown_1min",
+                court_datetime=court_datetime,
+            )
+
+        if step == "countdown_1min":
+            return ScenarioResponse(
+                messages=[_reminder(1, court_datetime)],  # type: ignore[arg-type]
+                next_scenario="scenario_1",
+                next_step="missed",
+                court_datetime=court_datetime,
+            )
+
+        if step == "missed":
+            dt = now_plus(15)
+            return ScenarioResponse(
+                messages=[
+                    f"We noticed you missed your court date. You'll need to reschedule.\n\n"
+                    f"For this demo, we'll reschedule you 15 min from now at {format_dt(dt)}"
+                    + _EXIT_HINT
+                ],
+                next_scenario="scenario_1",
+                next_step="countdown_7min",
+                court_datetime=dt,
+            )
+
+        raise ValueError(f"Unknown step for Scenario1.advance: {step!r}")

--- a/src/court_reminder/state.py
+++ b/src/court_reminder/state.py
@@ -1,1 +1,48 @@
 """Conversation state management."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Protocol
+
+
+@dataclass
+class ConversationState:
+    scenario: str = "home"
+    step: str = "welcome"
+    court_datetime: str | None = None
+
+
+class StateStore(Protocol):
+    def get(self, phone: str) -> ConversationState | None: ...
+    def save(self, phone: str, state: ConversationState) -> None: ...
+    def delete(self, phone: str) -> None: ...
+
+
+class InMemoryStateStore:
+    def __init__(self) -> None:
+        self._store: dict[str, ConversationState] = {}
+
+    def get(self, phone: str) -> ConversationState | None:
+        return self._store.get(phone)
+
+    def save(self, phone: str, state: ConversationState) -> None:
+        self._store[phone] = state
+
+    def delete(self, phone: str) -> None:
+        self._store.pop(phone, None)
+
+
+class AzureTableStateStore:
+    """Stubbed out — raises NotImplementedError. Implement before deploying to prod."""
+    def __init__(self, table_client: object) -> None:
+        self._table_client = table_client
+
+    def get(self, phone: str) -> ConversationState | None:
+        raise NotImplementedError
+
+    def save(self, phone: str, state: ConversationState) -> None:
+        raise NotImplementedError
+
+    def delete(self, phone: str) -> None:
+        raise NotImplementedError

--- a/src/court_reminder/twilio_handler.py
+++ b/src/court_reminder/twilio_handler.py
@@ -1,1 +1,57 @@
 """Twilio webhook handler for incoming and outgoing SMS."""
+
+from court_reminder.message_parser import parse
+from court_reminder.scenarios.home import HomeScenario
+from court_reminder.scenarios.scenario_1 import Scenario1
+from court_reminder.state import ConversationState, StateStore
+
+_EXIT_MESSAGE = "Thanks for trying the GA Court Reminder demo! Your session has ended."
+
+_SCENARIOS = {
+    "home": HomeScenario(),
+    "scenario_1": Scenario1(),
+}
+
+
+def handle_inbound_sms(phone: str, body: str, state_store: StateStore) -> list[str]:
+    """Process an inbound SMS and return outbound message bodies."""
+    msg = parse(body)
+
+    if msg.is_exit:
+        state_store.delete(phone)
+        return [_EXIT_MESSAGE]
+
+    state = state_store.get(phone) or ConversationState()
+    scenario = _SCENARIOS[state.scenario]
+    response = scenario.handle(state.step, body, state.court_datetime)
+
+    state_store.save(
+        phone,
+        ConversationState(
+            scenario=response.next_scenario,
+            step=response.next_step,
+            court_datetime=response.court_datetime,
+        ),
+    )
+    return response.messages
+
+
+def advance_scenario(phone: str, state_store: StateStore) -> list[str]:
+    """Advance the timed scenario step. Returns [] if the scenario has no timed steps."""
+    state = state_store.get(phone) or ConversationState()
+
+    if state.scenario == "home":
+        return []
+
+    scenario = _SCENARIOS[state.scenario]
+    response = scenario.advance(state.step, state.court_datetime)
+
+    state_store.save(
+        phone,
+        ConversationState(
+            scenario=response.next_scenario,
+            step=response.next_step,
+            court_datetime=response.court_datetime,
+        ),
+    )
+    return response.messages

--- a/tests/integration/local/test_demo_flow.py
+++ b/tests/integration/local/test_demo_flow.py
@@ -1,0 +1,98 @@
+"""Integration test: walk through the demo flow by calling handlers directly.
+
+No running server required — uses InMemoryStateStore.
+
+"""
+
+import pytest
+
+from court_reminder.state import InMemoryStateStore
+from court_reminder.twilio_handler import advance_scenario, handle_inbound_sms
+
+pytestmark = pytest.mark.integration_local
+
+
+def _make_store():
+    return InMemoryStateStore()
+
+
+def _sms(store, phone: str, body: str) -> str:
+    messages = handle_inbound_sms(phone, body, store)
+    return "\n".join(messages)
+
+
+def _advance(store, phone: str) -> list[str]:
+    return advance_scenario(phone, store)
+
+
+class TestDemoFlow:
+    def test_first_contact_sends_welcome(self):
+        store = _make_store()
+        text = _sms(store, "+15550000001", "hello")
+        assert "which scenario" in text.lower()
+
+    def test_invalid_input_loops_back_to_welcome(self):
+        store = _make_store()
+        _sms(store, "+15550000002", "hello")  # establish state
+        text = _sms(store, "+15550000002", "banana")
+        assert "which scenario" in text.lower()
+
+    def test_scenario_2_unavailable(self):
+        store = _make_store()
+        text = _sms(store, "+15550000003", "2")
+        assert "not available" in text.lower()
+        assert "which scenario" in text.lower()
+
+    def test_exit_from_home_ends_session(self):
+        store = _make_store()
+        text = _sms(store, "+15550000004", "EXIT")
+        assert "ended" in text.lower()
+
+    def test_full_scenario_1_flow(self):
+        store = _make_store()
+        phone = "+15550000005"
+
+        # Select scenario 1
+        text = _sms(store, phone, "1")
+        assert "10 minutes" in text
+        assert "EXIT" in text
+
+        # Advance: countdown_7min -> countdown_3min
+        messages = _advance(store, phone)
+        assert any("7 minute(s)" in m for m in messages)
+
+        # Advance: countdown_3min -> countdown_1min
+        messages = _advance(store, phone)
+        assert any("3 minute(s)" in m for m in messages)
+
+        # Advance: countdown_1min -> missed
+        messages = _advance(store, phone)
+        assert any("1 minute(s)" in m for m in messages)
+
+        # Advance: missed -> rescheduled
+        messages = _advance(store, phone)
+        assert any("reschedule" in m.lower() for m in messages)
+        assert any("15 min" in m for m in messages)
+
+    def test_inbound_sms_during_countdown_returns_acknowledgment(self):
+        store = _make_store()
+        phone = "+15550000006"
+        _sms(store, phone, "1")  # enter scenario_1
+        text = _sms(store, phone, "are we there yet?")
+        assert "EXIT" in text
+
+    def test_exit_during_countdown_ends_session(self):
+        store = _make_store()
+        phone = "+15550000007"
+        _sms(store, phone, "1")  # state is countdown_7min
+        text = _sms(store, phone, "END")
+        assert "ended" in text.lower()
+
+        # Next message should restart from welcome
+        text = _sms(store, phone, "hello")
+        assert "which scenario" in text.lower()
+
+    def test_advance_home_is_empty(self):
+        store = _make_store()
+        messages = _advance(store, "+15550000008")
+        assert messages == []

--- a/tests/integration/remote/test_azure_functions.py
+++ b/tests/integration/remote/test_azure_functions.py
@@ -1,9 +1,7 @@
 """Integration test: hit the local Azure Functions endpoint.
 
-Requires the function host to be running locally (`make run`).
-
-Usage:
-    make test-azure
+Requires the Azure Functions host to be running locally (default: http://localhost:7071).
+Tests are skipped automatically if the host is not reachable.
 """
 
 import urllib.error
@@ -32,13 +30,15 @@ def _post_json(path, body):
         pytest.skip(f"Function host not reachable: {exc}")
 
 
-def test_twilio_handler_with_name():
-    status, body = _post_json("twilioHandler", {"name": "World"})
+def test_twilio_handler_returns_home_menu():
+    """Any inbound SMS should return the demo home scenario selector."""
+    status, body = _post_json("twilioHandler", {"Body": "hello", "From": "+15550000001"})
     assert status == 200
-    assert "Hello, World" in body
+    assert "7, 3, 1 countdown" in body
 
 
-def test_twilio_handler_without_name():
+def test_twilio_handler_no_body():
+    """Missing Body/From still returns a valid TwiML response."""
     status, body = _post_json("twilioHandler", {})
     assert status == 200
-    assert "Pass a name" in body
+    assert "<Response>" in body

--- a/tests/integration/remote/test_twilio_sms.py
+++ b/tests/integration/remote/test_twilio_sms.py
@@ -1,12 +1,8 @@
 """Integration test: send countdown SMS reminders via Twilio.
 
-Requires a .env file at the repo root with Twilio credentials
-(see .template.env for a template).
-
-Usage:
-    uv run --group integration python -m pytest tests/integration/test_twilio_sms.py -v
-
-Check message logs at: https://console.twilio.com/us1/develop/sms/overview
+Requires a .env file at the repo root with Twilio credentials (see .template.env).
+Tests are skipped automatically if credentials are not configured.
+See Twilio message logs at: https://console.twilio.com/us1/develop/sms/overview
 """
 
 import os

--- a/tests/test_message_parser.py
+++ b/tests/test_message_parser.py
@@ -1,0 +1,35 @@
+import pytest
+
+from court_reminder.message_parser import ParsedMessage, parse
+
+
+@pytest.mark.parametrize("word", ["EXIT", "exit", "Finish", "finish", "END", "end"])
+def test_exit_words(word):
+    result = parse(word)
+    assert result.is_exit is True
+    assert result.scenario_choice is None
+
+
+@pytest.mark.parametrize("word", ["EXIT", "exit", "  exit  "])
+def test_exit_strips_whitespace(word):
+    assert parse(word).is_exit is True
+
+
+@pytest.mark.parametrize("choice,expected", [("1", 1), ("2", 2), ("99", 99)])
+def test_valid_scenario_choices(choice, expected):
+    result = parse(choice)
+    assert result.is_exit is False
+    assert result.scenario_choice == expected
+
+
+@pytest.mark.parametrize("body", ["banana", "", "hello world", "1a", "a1"])
+def test_invalid_input(body):
+    result = parse(body)
+    assert result.is_exit is False
+    assert result.scenario_choice is None
+
+
+def test_raw_preserved():
+    body = "  EXIT  "
+    result = parse(body)
+    assert result.raw == body

--- a/tests/test_scenario_1.py
+++ b/tests/test_scenario_1.py
@@ -1,0 +1,45 @@
+from court_reminder.scenarios.scenario_1 import Scenario1
+
+
+s1 = Scenario1()
+
+
+def test_countdown_7min_advance():
+    resp = s1.advance("countdown_7min", "2026-01-01T12:00:00+00:00")
+    assert resp.next_step == "countdown_3min"
+    assert "7 minute(s)" in resp.messages[0]
+    assert "EXIT" in resp.messages[0]
+
+
+def test_countdown_3min_advance():
+    resp = s1.advance("countdown_3min", "2026-01-01T12:00:00+00:00")
+    assert resp.next_step == "countdown_1min"
+    assert "3 minute(s)" in resp.messages[0]
+
+
+def test_countdown_1min_advance():
+    resp = s1.advance("countdown_1min", "2026-01-01T12:00:00+00:00")
+    assert resp.next_step == "missed"
+    assert "1 minute(s)" in resp.messages[0]
+
+
+def test_missed_advance_resets_to_countdown_7min():
+    resp = s1.advance("missed", "2026-01-01T12:00:00+00:00")
+    assert resp.next_step == "countdown_7min"
+    assert resp.court_datetime is not None
+    assert resp.court_datetime != "2026-01-01T12:00:00+00:00"
+    assert "reschedule" in resp.messages[0].lower()
+    assert "15 min" in resp.messages[0]
+
+
+def test_handle_during_countdown_returns_acknowledgment():
+    resp = s1.handle("countdown_7min", "are we there yet?", "2026-01-01T12:00:00+00:00")
+    assert resp.next_step == "countdown_7min"
+    assert resp.next_scenario == "scenario_1"
+    assert "EXIT" in resp.messages[0]
+
+
+def test_advance_unknown_step_raises():
+    import pytest
+    with pytest.raises(ValueError, match="Unknown step"):
+        s1.advance("bogus_step", None)

--- a/tests/test_scenario_home.py
+++ b/tests/test_scenario_home.py
@@ -1,0 +1,38 @@
+from court_reminder.scenarios.home import HomeScenario
+
+
+home = HomeScenario()
+
+
+def test_first_contact_sends_welcome():
+    resp = home.handle("welcome", "hello", None)
+    assert len(resp.messages) == 1
+    assert "which scenario" in resp.messages[0].lower()
+    assert resp.next_scenario == "home"
+    assert resp.next_step == "welcome"
+
+
+def test_valid_selection_1_routes_to_scenario_1():
+    resp = home.handle("welcome", "1", None)
+    assert resp.next_scenario == "scenario_1"
+    assert resp.next_step == "countdown_7min"
+    assert resp.court_datetime is not None
+    assert len(resp.messages) == 1
+    assert "10 minutes" in resp.messages[0]
+    assert "EXIT" in resp.messages[0]
+
+
+def test_unavailable_scenario_2_loops_back():
+    resp = home.handle("welcome", "2", None)
+    assert resp.next_scenario == "home"
+    assert resp.next_step == "welcome"
+    assert len(resp.messages) == 2
+    assert "not available" in resp.messages[0].lower()
+    assert "which scenario" in resp.messages[1].lower()
+
+
+def test_invalid_input_resends_welcome():
+    for body in ["banana", "99", "", "3"]:
+        resp = home.handle("welcome", body, None)
+        assert resp.next_scenario == "home"
+        assert "which scenario" in resp.messages[-1].lower()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,44 @@
+from court_reminder.state import ConversationState, InMemoryStateStore
+
+
+def test_default_state():
+    state = ConversationState()
+    assert state.scenario == "home"
+    assert state.step == "welcome"
+    assert state.court_datetime is None
+
+
+def test_get_missing_returns_none():
+    store = InMemoryStateStore()
+    assert store.get("+11234567890") is None
+
+
+def test_save_and_get():
+    store = InMemoryStateStore()
+    state = ConversationState(scenario="scenario_1", step="countdown_7min", court_datetime="2026-01-01T12:00:00+00:00")
+    store.save("+11234567890", state)
+    result = store.get("+11234567890")
+    assert result == state
+
+
+def test_save_overwrites():
+    store = InMemoryStateStore()
+    phone = "+11234567890"
+    store.save(phone, ConversationState(scenario="home"))
+    store.save(phone, ConversationState(scenario="scenario_1", step="missed"))
+    result = store.get(phone)
+    assert result is not None
+    assert result.scenario == "scenario_1"
+
+
+def test_delete_removes_state():
+    store = InMemoryStateStore()
+    phone = "+11234567890"
+    store.save(phone, ConversationState())
+    store.delete(phone)
+    assert store.get(phone) is None
+
+
+def test_delete_missing_is_noop():
+    store = InMemoryStateStore()
+    store.delete("+10000000000")  # should not raise

--- a/tests/test_twilio_handler.py
+++ b/tests/test_twilio_handler.py
@@ -1,0 +1,86 @@
+from court_reminder.state import ConversationState, InMemoryStateStore
+from court_reminder.twilio_handler import advance_scenario, handle_inbound_sms
+
+PHONE = "+11234567890"
+
+
+def store():
+    return InMemoryStateStore()
+
+
+def test_first_contact_sends_welcome():
+    s = store()
+    msgs = handle_inbound_sms(PHONE, "hello", s)
+    assert len(msgs) == 1
+    assert "which scenario" in msgs[0].lower()
+
+
+def test_select_scenario_1():
+    s = store()
+    msgs = handle_inbound_sms(PHONE, "1", s)
+    assert s.get(PHONE).scenario == "scenario_1"
+    assert s.get(PHONE).step == "countdown_7min"
+    assert s.get(PHONE).court_datetime is not None
+    assert len(msgs) == 1
+    assert "10 minutes" in msgs[0]
+
+
+def test_advance_through_full_countdown():
+    s = store()
+    handle_inbound_sms(PHONE, "1", s)  # enter scenario_1, state is now countdown_7min
+
+    # 7min -> 3min
+    msgs = advance_scenario(PHONE, s)
+    assert "7 minute(s)" in msgs[0]
+    assert s.get(PHONE).step == "countdown_3min"
+
+    # 3min -> 1min
+    msgs = advance_scenario(PHONE, s)
+    assert "3 minute(s)" in msgs[0]
+    assert s.get(PHONE).step == "countdown_1min"
+
+    # 1min -> missed
+    msgs = advance_scenario(PHONE, s)
+    assert "1 minute(s)" in msgs[0]
+    assert s.get(PHONE).step == "missed"
+
+    # missed -> countdown_7min (rescheduled)
+    msgs = advance_scenario(PHONE, s)
+    assert "reschedule" in msgs[0].lower()
+    assert s.get(PHONE).step == "countdown_7min"
+
+
+def test_exit_ends_session():
+    s = store()
+    handle_inbound_sms(PHONE, "1", s)
+    msgs = handle_inbound_sms(PHONE, "EXIT", s)
+    assert "ended" in msgs[0].lower()
+    assert s.get(PHONE) is None
+
+
+def test_new_message_after_exit_sends_welcome():
+    s = store()
+    handle_inbound_sms(PHONE, "EXIT", s)
+    msgs = handle_inbound_sms(PHONE, "hello", s)
+    assert "which scenario" in msgs[0].lower()
+
+
+def test_invalid_input_resends_welcome():
+    s = store()
+    msgs = handle_inbound_sms(PHONE, "banana", s)
+    assert "which scenario" in msgs[-1].lower()
+
+
+def test_select_scenario_2_unavailable():
+    s = store()
+    msgs = handle_inbound_sms(PHONE, "2", s)
+    assert len(msgs) == 2
+    assert "not available" in msgs[0].lower()
+    assert "which scenario" in msgs[1].lower()
+    assert s.get(PHONE).scenario == "home"
+
+
+def test_advance_home_returns_empty():
+    s = store()
+    msgs = advance_scenario(PHONE, s)
+    assert msgs == []


### PR DESCRIPTION
## Summary

- Implements the full inbound SMS conversation engine: `message_parser` → `twilio_handler` → scenario dispatch → `StateStore`
- Adds `HomeScenario` (demo entry point + scenario selector) and `Scenario1` (7-3-1 countdown flow with missed-court rescheduling)
- Adds `advanceScenario` HTTP route for timed step advancement (called externally on a schedule)
- Reorganizes integration tests into `local/` (no server needed) and `remote/` (Azure host or Twilio credentials) subdirectories
- Adds `scripts/conv_simulation.py` for terminal/browser conversation walkthroughs

## Architecture

```
Twilio POST → twilioHandler → handle_inbound_sms()
                                ↓
                         ConversationState (phone-keyed)
                                ↓
                    HomeScenario | Scenario1 (BaseScenario)
                         handle() | advance()
                                ↓
                         ScenarioResponse → TwiML XML
```

State is backed by `InMemoryStateStore` (local/demo) or `AzureTableStateStore` (stub — not yet implemented). Controlled via `STATE_BACKEND=memory` env var.

## Test plan

- [x] `make test` — all unit tests pass
- [x] `make test-integration` — local integration flow passes (no server needed)
- [x] `make func-run` then `make test-azure` — Azure Functions host integration passes
- [x] `make conv-generate && make conv-browser` — conversation simulation renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Test Results

`make func-run`: set up local API, used in integration test

<img width="680" height="243" alt="Screenshot 2026-03-14 at 3 44 52 PM" src="https://github.com/user-attachments/assets/3c2259c5-0ddd-42f1-aa5c-ad74f678ce8f" />

`make test`

<img width="840" height="255" alt="Screenshot 2026-03-14 at 3 47 14 PM" src="https://github.com/user-attachments/assets/7418a7aa-d168-45fa-9a5a-59700c497dac" />

`make test-integration`

<img width="1029" height="442" alt="Screenshot 2026-03-14 at 3 46 35 PM" src="https://github.com/user-attachments/assets/d104e317-b124-47df-9a72-e371bf13e0cf" />

`make test-azure`

<img width="1024" height="203" alt="Screenshot 2026-03-14 at 3 47 57 PM" src="https://github.com/user-attachments/assets/4638f30b-efb7-4764-97f8-4d5145067448" />

`make conv-generate && make conv-browser` (saved copy of HTML in comments)

<img width="827" height="60" alt="Screenshot 2026-03-14 at 3 49 24 PM" src="https://github.com/user-attachments/assets/a15f45ec-1e45-4507-a5f9-b56ecbf29ffa" />
